### PR TITLE
[Feature] Normal markdown extension support

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,12 +30,17 @@ module.exports = {
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,
-    `gatsby-plugin-mdx`,
+    {
+      resolve: `gatsby-plugin-mdx`,
+      options: {
+        extensions: [`.mdx`, `.md`],
+      }
+    },
     {
       resolve: "gatsby-source-filesystem",
       options: {
         name: "posts",
-        path: `${__dirname}/src/markdown-pages`
+        path: `${__dirname}/src/markdown-pages`,
       },
     }
   ],

--- a/src/markdown-pages/normal-markdown.md
+++ b/src/markdown-pages/normal-markdown.md
@@ -1,0 +1,3 @@
+# Normal markdown
+
+_This is an example of a normal markdown page._


### PR DESCRIPTION
This feature lets you create pages from normal `.md` files by letting the mdx processor convert those files.

Closes #6 