### PR TITLE
Add markdown link checking plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,19 +32,25 @@ module.exports = {
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,
     {
-       resolve: `gatsby-plugin-mdx`,
-       options: {
-         extensions: [`.mdx`, `.md`],
-         gatsbyRemarkPlugins: [
-           {
-             resolve: `gatsby-remark-images`,
-             options: {
-               maxWidth: 590,
-             },
-           },
-         ],
-         plugins: ['gatsby-remark-images'],
-       },
+      resolve: `gatsby-plugin-mdx`,
+      options: {
+        extensions: [`.mdx`, `.md`],
+        gatsbyRemarkPlugins: [
+          {
+            resolve: `gatsby-remark-images`,
+            options: {
+              maxWidth: 590,
+            },
+          },
+          {
+            resolve: `gatsby-remark-check-links`,
+            options: {
+              verbose: false
+            }
+          },
+        ],
+        plugins: ["gatsby-remark-images"],
+      },
     },
     {
       resolve: "gatsby-source-filesystem",
@@ -63,6 +69,6 @@ module.exports = {
         name: "posts",
         path: `${__dirname}/src/data`,
       },
-    }
+    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gatsby-plugin-react-helmet": "^3.1.16",
     "gatsby-plugin-react-svg": "^2.1.2",
     "gatsby-plugin-sharp": "^2.3.4",
+    "gatsby-remark-check-links": "^2.1.0",
     "gatsby-remark-images": "^3.1.37",
     "gatsby-source-filesystem": "^2.1.39",
     "gatsby-transformer-remark": "^2.6.42",

--- a/src/markdown-pages/nested/page.mdx
+++ b/src/markdown-pages/nested/page.mdx
@@ -1,3 +1,12 @@
 # Nested Page
 
 _This is an example of a nested page._
+
+This is a [link to the example page](/example/)
+
+[External link](https://www.google.com)
+
+Currently, [links][] that use reference style are not checked, but there is an [issue][] tracking this in the plugin's repo.
+
+[links]: /foo/
+[issue]: https://github.com/trevorblades/gatsby-remark-check-links/issues/4

--- a/yarn.lock
+++ b/yarn.lock
@@ -5675,6 +5675,13 @@ gatsby-react-router-scroll@^2.1.19:
     scroll-behavior "^0.9.10"
     warning "^3.0.0"
 
+gatsby-remark-check-links@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-check-links/-/gatsby-remark-check-links-2.1.0.tgz#8e8a2b1b82ac6c516fcc2074e8f806e2c0d53571"
+  integrity sha512-TbhT8oVlAgJfxe0WUQWDOb0kLkMUYo1N4AfFstejClPWO4OjRlznt3IMW3weQkwuweiovF5cxVpQcFrkCGVFBw==
+  dependencies:
+    unist-util-visit "^1.4.1"
+
 gatsby-remark-images@^3.1.37:
   version "3.1.37"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.1.37.tgz#e270630e208470326faf51e9cec34ffd3cded09c"


### PR DESCRIPTION
Adds link checking for markdown files.

**Note:** It does not currently work with link definitions, but there is an issue on the plugin repo to address it.

closes #17 
