### PR TITLE
Add support for importing _includes files

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     createNodeField({
       name: "slug",
       node,
-      value: `${ value }`,
+      value: `${value}`,
     })
   }
 }
@@ -32,16 +32,20 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 
   if (result.errors) {
     reporter.panicOnBuild('🚨  ERROR: Loading "createPages" query')
-  } 
+  }
 
   const posts = result.data.allMdx.edges
 
-  posts.forEach(({ node  }, index) => {
-    createPage({
-      path: node.fields.slug,
-      context: { id: node.id  },
-      component: path.resolve(`./src/layouts/MdxLayout/mdxLayout.js`)
-    })
+  posts.forEach(({ node }, index) => {
+    const urlPath = node.fields.slug
+
+    if (!urlPath.includes("_includes")) {
+      createPage({
+        path: urlPath,
+        context: { id: node.id },
+        component: path.resolve(`./src/layouts/MdxLayout/mdxLayout.js`),
+      })
+    }
   })
 }
 
@@ -55,8 +59,8 @@ exports.onCreateWebpackConfig = ({
   actions.setWebpackConfig({
     resolve: {
       alias: {
-        DocComponents: path.resolve(__dirname, 'src/doc-components/')
-      }
-    }
+        DocComponents: path.resolve(__dirname, "src/doc-components/"),
+      },
+    },
   })
 }

--- a/src/markdown-pages/_includes/re-usable-content.mdx
+++ b/src/markdown-pages/_includes/re-usable-content.mdx
@@ -1,0 +1,18 @@
+## Phrygiis vultu
+
+Est et est Hesperiae Tyrioque quamquam habet inani ore esse? Daedale totidem
+erant illa peterem, fortibus aere. Tigres arce gyrum receptus Aeneas iuncturas
+dat ante, viris manes triumphos funere lustrat at fuerant.
+
+Rectum Polyphemon aevo: canoro. Est guttura utque, _sit_ ille colla Iove feroces
+inque si Elide nomine; est lacerta in vulnus. Fastigiaque tunc Melaneus?
+
+1. Nec fine iurabat mox sive et pennis
+2. Et contulit fores
+3. Ramos ex corpore canam tu incursat iram
+
+Fuit **patria** quasque Persea noctis colubris ruinam tolluntur crudelis Theseus
+gloria sine. Inmeritae ferunt, quod et mactati et legem, est: idem est? Arcu
+dextris forte nec que dare moventem artus nulla aquis umor evulsum oscula nec
+incalfacit optavit nondum labefactaque hoste! Frontemque adhuc, vir succedit,
+sedatis **totidemque venisset relatis** durataeque fortissime flammae.

--- a/src/markdown-pages/example.mdx
+++ b/src/markdown-pages/example.mdx
@@ -1,5 +1,7 @@
 import GlobalVariable from "DocComponents/GlobalVariable"
 
+import ExampleSnippet from "./_includes/re-usable-content.mdx"
+
 # Example
 
 _This is a temporary page for testing MDX page creation._
@@ -16,3 +18,4 @@ Example variable: <GlobalVariable>exampleVariable</GlobalVariable>
 Name prop takes precedence over inner tag content:
 
 <GlobalVariable name="version">exampleVariable</GlobalVariable>
+<ExampleSnippet />


### PR DESCRIPTION
This PR adds support for importing mdx and markdown files in an `_includes` directory without generating separate pages for those files.

This feature requires documentation.