### PR TITLE
Callout markdown rendering

### DIFF
--- a/src/markdown-pages/callouts.md
+++ b/src/markdown-pages/callouts.md
@@ -68,4 +68,8 @@ These Callouts also support **markdown**!
 
 However, they are supposed to be _simple_ message boxes, so should they?
 
+| Header 1 | Header 2     |
+| -------- | ------------ |
+| Content  | More content |
+
 </Callout>

--- a/src/markdown-pages/callouts.md
+++ b/src/markdown-pages/callouts.md
@@ -6,9 +6,11 @@ import Example from "./example.mdx"
 
 # Callouts
 
-Callouts are helpful when drawing attention to important information. To add a callout in your topic, use the following syntax:
+Callouts are helpful when drawing attention to important information.
 
-```
+To add a callout in your topic, use the following syntax:
+
+```jsx
 <Callout type="tip" header="Short description or title">
   Place message about a tip here.
 </Callout>
@@ -18,6 +20,22 @@ Sample output:
 
 <Callout type="tip" header="Short description or title">
   Place message about a tip here.
+</Callout>
+
+To use markdown inside a callout, add a space between the tag and content:
+
+```jsx
+<Callout type="tip" header="Short description or title">
+  Place **message** about a tip here.
+</Callout>
+```
+
+Output:
+
+<Callout type="tip" header="Short description or title">
+
+Place **message** about a tip here.
+
 </Callout>
 
 ## Tip
@@ -45,7 +63,9 @@ Sample output:
 ## Error
 
 <Callout type="error" header="Oops!">
-  These Callouts do not support **markdown**.
-  <br />
-  They are supposed to be simple message boxes, so should they?
+
+These Callouts also support **markdown**!
+
+However, they are supposed to be _simple_ message boxes, so should they?
+
 </Callout>

--- a/src/markdown-pages/normal-markdown.md
+++ b/src/markdown-pages/normal-markdown.md
@@ -13,7 +13,9 @@ This is version <GlobalVariable name='version'/> of a Doc site created by <Globa
 | Content  | More content |
 
 <Callout type="tip" header="Guess what!">
-  The `yarn prettier` command automatically reformats your messy tables! Yep. So cool...
+
+The `yarn prettier` command automatically reformats your messy tables! Yep. So cool...
+
 </Callout>
 
 ## Example from DevDocs:


### PR DESCRIPTION
Add a message about using markdown in Callout components.

**Note:**
This should only be done in `.md` files otherwise prettier will complain. This is a known bug in prettier regarding jsx parsing and should be fixed in prettier 2.0.

Closes #67