### PR TITLE
Add mermaid example to show parity in devdocs

### DIFF
--- a/src/data/pageGroups/cloud.yml
+++ b/src/data/pageGroups/cloud.yml
@@ -9,3 +9,5 @@ pages:
     url: /cloud/cloud-architecture/
   - title: Comparison table
     url: /cloud/cloud-table/
+  - title: Magento payment provider gateway
+    url: /cloud/mermaid/

--- a/src/markdown-pages/_includes/re-usable-content.mdx
+++ b/src/markdown-pages/_includes/re-usable-content.mdx
@@ -16,3 +16,8 @@ gloria sine. Inmeritae ferunt, quod et mactati et legem, est: idem est? Arcu
 dextris forte nec que dare moventem artus nulla aquis umor evulsum oscula nec
 incalfacit optavit nondum labefactaque hoste! Frontemque adhuc, vir succedit,
 sedatis **totidemque venisset relatis** durataeque fortissime flammae.
+
+| heading | A   | B   |
+| ------- | --- | --- |
+| thing 1 | yes | no  |
+| thing 2 | no  | yes |

--- a/src/markdown-pages/cloud/mermaid.mdx
+++ b/src/markdown-pages/cloud/mermaid.mdx
@@ -30,11 +30,11 @@ sequenceDiagram
 
 Magento payment provider supports the following payment operations:
 
--  **authorize**: process authorization transaction; funds are blocked on customer account, but not withdrawn
--  **sale**: process authorization transaction and capture automatically, funds are withdrawn
--  **capture**: withdraw previously authorized amount
--  **refund**: return previously withdrawn customer funds
--  **void**: cancel transfer of funds from customer account
+- **authorize**: process authorization transaction; funds are blocked on customer account, but not withdrawn
+- **sale**: process authorization transaction and capture automatically, funds are withdrawn
+- **capture**: withdraw previously authorized amount
+- **refund**: return previously withdrawn customer funds
+- **void**: cancel transfer of funds from customer account
 
 <!-- link definitions -->
 

--- a/src/markdown-pages/cloud/mermaid.mdx
+++ b/src/markdown-pages/cloud/mermaid.mdx
@@ -2,6 +2,12 @@
 
 You can build useful diagrams to illustrate many types of content using the [mermaid plugin][mermaid]. Consider the following example of a Sequence diagram from the [DevDocs Payment Provider Gateway guide][payment]:
 
+## What is Magento payment provider gateway
+
+The Magento payment provider gateway is a mechanism that allows you to integrate your stores with payment service providers. As a result, you can create and handle transactions based on order details.
+
+The following diagram shows a simplified interaction flow between Magento sales management and external payment service provider using Magento payment provider gateway:
+
 ```mermaid
 sequenceDiagram
    participant sales as Sales Management
@@ -21,6 +27,14 @@ sequenceDiagram
    deactivate payment1
    deactivate sales
 ```
+
+Magento payment provider supports the following payment operations:
+
+-  **authorize**: process authorization transaction; funds are blocked on customer account, but not withdrawn
+-  **sale**: process authorization transaction and capture automatically, funds are withdrawn
+-  **capture**: withdraw previously authorized amount
+-  **refund**: return previously withdrawn customer funds
+-  **void**: cancel transfer of funds from customer account
 
 <!-- link definitions -->
 

--- a/src/markdown-pages/cloud/mermaid.mdx
+++ b/src/markdown-pages/cloud/mermaid.mdx
@@ -1,0 +1,28 @@
+# Magento payment provider gateway
+
+You can build useful diagrams to illustrate many types of content using the [mermaid plugin][mermaid]. Consider the following example of a Sequence diagram from the [DevDocs Payment Provider Gateway guide][payment]:
+
+```mermaid
+sequenceDiagram
+   participant sales as Sales Management
+   participant payment1 as Payment Gateway
+   participant payment2 as Payment Processor
+   Note over sales: process order
+
+   activate sales
+   sales->>payment1: perform action
+   activate payment1
+   payment1->>payment1: get command
+   payment1->>payment2: execute
+   activate payment2
+   payment2-->>payment1: response
+   deactivate payment2
+   payment1-->>sales: transaction details
+   deactivate payment1
+   deactivate sales
+```
+
+<!-- link definitions -->
+
+[mermaid]: http://mermaid-js.github.io/mermaid/#/
+[payment]: https://devdocs.magento.com/guides/v2.3/payments-integrations/payment-gateway/payment-gateway-intro.html


### PR DESCRIPTION
Mermaid takes some getting used to, but it is VERY handy.
I found an ideal Sequence chart in DevDocs for an appropriate example.
https://devdocs.magento.com/guides/v2.3/payments-integrations/payment-gateway/payment-gateway-intro.html
