### PR TITLE
Fix wandering table of contents

### DIFF
--- a/src/components/App/app.module.css
+++ b/src/components/App/app.module.css
@@ -48,11 +48,12 @@
 
   .rightSidebar {
     display: block;
+    width: 200px;
   }
 }
 @media screen and (min-device-width: 1024px) {
   .main {
-    width: calc(100vw - 300px);
+    width: calc(100vw - 600px);
   }
 
   .topicContent {
@@ -66,6 +67,7 @@
     width: calc(100vw - 650px);
   }
 
-  .topicContent {
+  .rightSidebar {
+    width: 250px;
   }
 }


### PR DESCRIPTION
This PR sets a constant width for the Table of Contents to prevent it from unexpectedly moving to the top of the topic content when headers are too long.